### PR TITLE
Raise if requests are not performed as expected

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,47 @@ A response can also throw an exception as follows.
     # All calls to 'http://twitter.com/api/1/foobar' will throw exception.
 
 
+Responses as a context manager
+------------------------------
+
+.. code-block:: python
+
+    import responses
+    import requests
+
+
+    def test_my_api():
+        with responses.mock:
+            responses.add(responses.GET, 'http://twitter.com/api/1/foobar',
+            body='{}', status=200,
+            content_type='application/json')
+            resp = requests.get('http://twitter.com/api/1/foobar')
+
+            assert resp.status_code == 200
+        # outside the context manager,
+        # from now on requests will perform real http requests.
+        resp = requests.get('http://twitter.com/api/1/foobar')
+        resp.status_code == 404
+
+
+Responses tells you if one expected requests has not been performed
+-------------------------------------------------------------------
+
+.. code-block:: python
+
+    import responses
+    import requests
+
+
+    def test_my_api():
+        with responses.RequestsMock() as requests_mock:
+            requests_mock.add(responses.GET, 'http://twitter.com/api/1/foobar',
+            body='{}', status=200,
+            content_type='application/json')
+
+        AssertionError: Not all requests has been executed [(u'GET', u'http://twitter.com/api/1/foobar')]
+
+
 .. note:: Responses requires Requests >= 1.0
 
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -281,3 +281,20 @@ def test_activate_doesnt_change_signature_for_method():
     assert argspec == getargspec(decorated_test_function)
     assert decorated_test_function(1, 2) == test_case.test_function(1, 2)
     assert decorated_test_function(3) == test_case.test_function(3)
+
+
+def test_assert_all_requests_are_fired():
+    def run():
+        with pytest.raises(AssertionError) as excinfo:
+            with responses.RequestsMock(
+                    assert_all_requests_are_fired=True) as m:
+                m.add(responses.GET, 'http://example.com', body=b'test')
+        assert 'http://example.com' in str(excinfo.value)
+        assert responses.GET in str(excinfo)
+
+        # check that assert_all_requests_are_fired default to True
+        with pytest.raises(AssertionError):
+            with responses.RequestsMock() as m:
+                m.add(responses.GET, 'http://example.com', body=b'test')
+    run()
+    assert_reset()


### PR DESCRIPTION
I expect from my testing tools to detect inconsistencies and unpredictable behaviour.
This is why I would like that `responses` helps me to detect request that has not been performed unlike it should.

I implemented it in a way that is backward compatible, but I'm in favour of enabling this behaviour by default.