### PR TITLE
Feature: show method for "connection refused" messages

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -208,7 +208,8 @@ class RequestsMock(object):
 
         # TODO(dcramer): find the correct class for this
         if match is None:
-            error_msg = 'Connection refused: {0}'.format(request.url)
+            error_msg = 'Connection refused: {0} {1}'.format(request.method,
+                                                             request.url)
             response = ConnectionError(error_msg)
 
             self._calls.add(request, response)


### PR DESCRIPTION
This PR adds the method name to "connection refused" errors to aid debugging, as (for example) it's quite easy when duplicating a previous test as the basis for a new test to forget to change the method (e.g. `put` to `post`).